### PR TITLE
make file quarantine optional

### DIFF
--- a/modules/azure-storage-blob/container-job.tf
+++ b/modules/azure-storage-blob/container-job.tf
@@ -34,6 +34,10 @@ resource "azurerm_container_app_job" "proj_container_app_clamav_job" {
         name  = "WORK_DIR"
         value = "/${local.datahub_temp_name}"
       }
+      env {
+        name  = "ENABLE_QUARANTINE"
+        value = var.enable_quarantine
+      }
       volume_mounts {
         name = local.datahub_temp_name
         path = "/${local.datahub_temp_name}"

--- a/modules/azure-storage-blob/variables.tf
+++ b/modules/azure-storage-blob/variables.tf
@@ -121,5 +121,5 @@ variable "clamav_job_uai" {}
 variable "aca_job_env_uai" {}
 variable "clamav_docker_image" {}
 variable "sas_docker_image" {}
-variable "enable_clamav" { default = false } # blob events still to be queued even if disabled so that they can be scanned later once enabled
-
+variable "enable_clamav" { default = false }     # blob events still to be queued even if disabled so that they can be scanned later once enabled
+variable "enable_quarantine" { default = false } # if enabled, infected files are copied to datahub-quarantine container

--- a/templates/azure-storage-blob/azure-storage-blob-template.variables.tf.json
+++ b/templates/azure-storage-blob/azure-storage-blob-template.variables.tf.json
@@ -15,6 +15,10 @@
     "enable_clamav": {
       "type": "bool",
       "default": false
+    },
+    "enable_quarantine": {
+      "type": "bool",
+      "default": false
     }
   }
 }

--- a/templates/azure-storage-blob/azure-storage-blob.tf
+++ b/templates/azure-storage-blob/azure-storage-blob.tf
@@ -15,6 +15,7 @@ module "azure_storage_blob_module" {
   clamav_job_uai               = module.resource_group_module.clamav_job_uai
   container_app_env_id         = module.resource_group_module.container_app_env_id
   aca_job_env_uai              = module.resource_group_module.aca_job_env_uai
+  enable_quarantine            = var.enable_quarantine
 
   # optional variables
   az_tenant_id              = var.az_tenant_id

--- a/test-project/azure-container-app.auto.tfvars.json
+++ b/test-project/azure-container-app.auto.tfvars.json
@@ -1,10 +1,5 @@
 {
-  "container_app_secrets": [
-    {
-      "name": "TEST-SECRET",
-      "secret_id": "https://fsdh-proj-s2509d-dev-kv.vault.azure.net/secrets/storage-key/0f63f366c76e498495d384e2a1ca3637"
-    }
-  ],
+  "container_app_secrets": [],
   "container_app_list": [
     {
       "name": "nginx",

--- a/test-project/new-project-template.auto.tfvars.json
+++ b/test-project/new-project-template.auto.tfvars.json
@@ -1,7 +1,7 @@
 {
     "az_subscription_id": "bc4bcb08-d617-49f4-b6af-69d6f10c240b",
     "az_tenant_id": "8c1a4d93-d828-4d0e-9303-fd3bd611c822",
-    "project_cd": "s2509d",
+    "project_cd": "s2511b",
     "environment_classification": "U",
     "environment_name": "dev",
     "az_location": "canadacentral",

--- a/test-project/project.tfbackend
+++ b/test-project/project.tfbackend
@@ -1,4 +1,4 @@
 resource_group_name  = "sp-datahub-iac-rg"
 storage_account_name = "sscdataterraformbackend"
 container_name       = "fsdh-project-v2"
-key                  = "fsdh-sample-project.tfstate"
+key                  = "test-project.tfstate"


### PR DESCRIPTION
The FSDH team decided to disable file quarantine by default. In other words, all infected files would be deleted with saving a copy to a quarantine area. This change implements this team decision.